### PR TITLE
Fix calculation for December

### DIFF
--- a/custom_components/eero/api/__init__.py
+++ b/custom_components/eero/api/__init__.py
@@ -5,6 +5,8 @@ import os
 import pytz
 import requests
 
+from dateutil import relativedelta
+
 from .account import Account
 from .const import (
     ACTIVITY_MAP,
@@ -74,7 +76,7 @@ class EeroAPI(object):
             cadence = CADENCE_DAILY
         elif period == PERIOD_MONTH:
             start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
-            end = start.replace(month=start.month+1) - datetime.timedelta(minutes=1)
+            end = start + relativedelta.relativedelta(months=1) - datetime.timedelta(minutes=1)
             cadence = CADENCE_DAILY
         else:
             return (start, end, cadence)


### PR DESCRIPTION
Woke up to the following traceback and a non-functioning integration. This PR fixes it.

```python
2021-12-01 09:20:50 ERROR (MainThread) [custom_components.eero] Unexpected error fetching Eero data: month must be in 1..12
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 187, in _async_refresh
    self.data = await self._async_update_data()
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 147, in _async_update_data
    return await self.update_method()
  File "/config/custom_components/eero/__init__.py", line 176, in async_update_data
    return await hass.async_add_executor_job(api.update)
  File "/usr/local/lib/python3.9/concurrent/futures/thread.py", line 52, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/config/custom_components/eero/api/__init__.py", line 156, in update
    activity_data[resource][activity] = self.update_activity(
  File "/config/custom_components/eero/api/__init__.py", line 176, in update_activity
    start, end, cadence = self.define_period(period=ACTIVITY_MAP[activity][2], timezone=timezone)
  File "/config/custom_components/eero/api/__init__.py", line 77, in define_period
    end = start.replace(month=start.month+1) - datetime.timedelta(minutes=1)
```