### PR TITLE
fixes #35 and #30

### DIFF
--- a/custom_components/eero/api/__init__.py
+++ b/custom_components/eero/api/__init__.py
@@ -70,7 +70,8 @@ class EeroAPI(object):
             end = start + relativedelta.relativedelta(days=1) - datetime.timedelta(minutes=1)
             cadence = CADENCE_HOURLY
         elif period == PERIOD_WEEK:
-            start = now.replace(day=now.day-(now.weekday()+1), hour=0, minute=0, second=0, microsecond=0)
+            start = now - relativedelta.relativedelta(days=now.weekday()+1)
+            start = start.replace(hour=0, minute=0, second=0, microsecond=0)
             end = start + relativedelta.relativedelta(weeks=1) - datetime.timedelta(minutes=1)
             cadence = CADENCE_DAILY
         elif period == PERIOD_MONTH:


### PR DESCRIPTION
uses `relativedelta` for calculating `start` of the week instead of subtraction from the date (which breaks during the beginning of each month. e.g. today's date = 1, day of week = 2 => start = 1-(2+1)=-2)