### PR TITLE
Deprecation refactor for async_get_registry and async_setup_platforms

### DIFF
--- a/custom_components/eero/__init__.py
+++ b/custom_components/eero/__init__.py
@@ -346,7 +346,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             schema=SET_BLOCKED_APPS_SCHEMA,
         )
 
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 

--- a/custom_components/eero/__init__.py
+++ b/custom_components/eero/__init__.py
@@ -146,8 +146,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         conf_eeros, conf_profiles, conf_clients = [], [], []
     conf_identifiers = [(DOMAIN, resource_id) for resource_id in conf_networks + conf_eeros + conf_profiles + conf_clients]
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    device_registry = hass.helpers.device_registry.async_get(hass)
+    entity_registry = hass.helpers.entity_registry.async_get(hass)
     for device_entry in hass.helpers.device_registry.async_entries_for_config_entry(device_registry, entry.entry_id):
         if all([bool(resource_id not in conf_identifiers) for resource_id in device_entry.identifiers]):
             device_registry.async_remove_device(device_entry.id)


### PR DESCRIPTION
Refactor async_get_registry to async_get and async_setup_platforms to async_forward_entry_setups as both methods are deprecated.

Resolved issue #41 and #48 for me.