### PR TITLE
feat: expose guest password on switch

### DIFF
--- a/custom_components/eero/switch.py
+++ b/custom_components/eero/switch.py
@@ -115,6 +115,7 @@ SWITCH_DESCRIPTIONS: list[EeroSwitchEntityDescription] = [
         name="Guest Network",
         extra_attrs={
             "guest_network_name": lambda resource: getattr(resource, "guest_network_name"),
+            "guest_network_password": lambda resource: getattr(resource, "guest_network_password"),
             "connected_guest_clients": lambda resource: getattr(resource, "connected_guest_clients_count"),
         },
     ),


### PR DESCRIPTION
I've added a card to the dashboard that shows the QR code but also shows the SSID & Password for the guest account (allows guest to login w/ a laptop), to facilitate this I needed to add the guest password to the guest switch (that was the easiest as the name was already there).

I don't think there's any security concern with this as the integration is already producing the QR code which has the same information (or at least it is retrievable).

Thanks for the integration -- I started down the path myself before realizing you'd already built 95% of what I was looking for -- I've gotta remind myself to google first 🤦 