### PR TITLE
Fix AttributeError when resource disappears from API response

### DIFF
--- a/custom_components/eero/__init__.py
+++ b/custom_components/eero/__init__.py
@@ -578,12 +578,24 @@ class EeroEntity(CoordinatorEntity):
 
     @property
     def resource(self) -> EeroResource | None:
-        """Return the state attributes."""
+        """Return the resource for this entity."""
         if self.resource_id:
-            for resource in self.network.resources:
+            network = self.network
+            if network is None:
+                return None
+            for resource in network.resources:
                 if resource.id == self.resource_id:
                     return resource
+            return None  # Resource not found, don't fallback to network
         return self.network
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        if not super().available:
+            return False
+        # Entity is unavailable if its resource cannot be found
+        return self.resource is not None
 
     @property
     def unique_id(self) -> str:


### PR DESCRIPTION
## Summary

Fixes the recurring `AttributeError: 'EeroNetwork' object has no attribute 'connected'` error that occurs when devices/clients temporarily disappear from the Eero API response.

**Root Cause:** When a client or profile disappears from the API response (e.g., device disconnects), the `resource` property incorrectly fell back to returning the `EeroNetwork` object instead of indicating the resource was not found. This caused `AttributeError` exceptions because `EeroNetwork` doesn't have attributes like `connected` that exist on `EeroClient`/`EeroProfile`.

**Changes:**
- Fix `resource` property to return `None` when a `resource_id` is set but the resource cannot be found
- Add `available` property that returns `False` when resource is not found, preventing Home Assistant from calling state properties on unavailable entities

## Test Plan

- [x] Deployed to local Home Assistant installation
- [x] Verified no errors in logs after multiple polling cycles
- [x] Confirmed integration continues to function normally

Fixes #147

🤖 Generated with [Claude Code](https://claude.ai/code)