### PR TITLE
Fix KeyError in device cleanup on Python 3.14

### DIFF
--- a/custom_components/eero/__init__.py
+++ b/custom_components/eero/__init__.py
@@ -346,7 +346,10 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
                     device_entry.name,
                     device_entry.model,
                 )
-                device_registry.async_remove_device(device_entry.id)
+                try:
+                    device_registry.async_remove_device(device_entry.id)
+                except (KeyError, ValueError):
+                    pass
             else:
                 for entity_entry in er.async_entries_for_device(
                     entity_registry, device_entry.id


### PR DESCRIPTION
## Summary

- Wrap `device_registry.async_remove_device()` in try/except to handle `KeyError` when a device has already been removed from the registry
- Without this fix, the integration fails to set up (`setup_error`) on Home Assistant running Python 3.14

The crash occurs during device cleanup in `__init__.py` line 349. The `async_remove_device` call raises `KeyError` when the device is no longer in the registry — Python 3.14's `ReadOnlyDict.pop()` surfaces this as an unhandled exception.

Fixes #165 (Broken after HA core update)

## Testing

Tested on Home Assistant 2026.7.x (Python 3.14.5) running on HA Green (aarch64). After applying the fix, the eero integration sets up successfully and all network/device tracking entities appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)