### PR TITLE
Expose wireless band, channel, and channel width on client device trackers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Custom component to allow control of Eero networks in [Home Assistant](https://h
 - Control network properties (ex. guest network, Eero Plus features, Eero Labs features)
 - Pause access for profiles and/or clients
 - Control content filters for profiles
-- Device tracker entities for clients and profiles
+- Device tracker entities for clients and profiles (wireless clients also report `band`, `channel`, and `channel_width` attributes)
 - Sensors for various metrics
 - Button entities to control features that require network restarts
 - Select and time entities to control nightlight features for Eero Beacon devices

--- a/custom_components/eero/device_tracker.py
+++ b/custom_components/eero/device_tracker.py
@@ -210,4 +210,16 @@ class EeroDeviceTrackerEntity(EeroEntity):
             if manufacturer := self.resource.manufacturer:
                 attrs[ATTR_MANUFACTURER] = manufacturer
             attrs["network_name"] = self.network.name
+            if self.resource.wireless:
+                frequency, frequency_unit = self.resource.interface_frequency
+                if frequency:
+                    attrs["band"] = (
+                        f"{frequency} {frequency_unit}".strip()
+                        if frequency_unit
+                        else str(frequency)
+                    )
+                if self.resource.channel is not None:
+                    attrs["channel"] = self.resource.channel
+                if channel_width := self.resource.channel_width_rx:
+                    attrs["channel_width"] = channel_width
         return attrs


### PR DESCRIPTION
## Summary
Adds `band`, `channel`, and `channel_width` attributes to connected **wireless** client `device_tracker` entities, sourced from data the API already returns (`interface.frequency`, `channel`, `connectivity.rx_rate_info.channel_width`).

Example attributes on a wireless client:
```
band: 5 GHz
channel: 153
channel_width: WIDTH_80MHz
```

## Why
Makes it easy to see how clients are distributed across bands (2.4 / 5 / 6 GHz) and channels — handy for spotting devices parked on a band with poor signal, or auditing 2.4 vs 5 GHz usage across a mesh.

## Notes
- Only added for wireless clients while connected (wired clients have no band).
- No new entities; just attributes on the existing device_tracker, consistent with the current `connected_to` / `connection_type` attributes.
- Verified populating correctly across a live network (2.4/5/6 GHz clients).
